### PR TITLE
area, union, cors

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -34,6 +34,7 @@ GEOS_LIBRARY_PATH="C:/PostgreSQL/XXX/bin/libgeos_c.dll"
 DOCKER_HOST=ssh://user@server.example.com
 
 ALLOWED_HOSTS="example.com,example2.com"
+CORS_ALLOWED_ORIGINS="http://localhost:5173,https://sitn.ne.ch"
 
 ROOTURL="/apps"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ asgiref==3.5.2
 certifi==2022.12.7
 charset-normalizer==3.0.1
 Django==4.0.5
+django-cors-headers==4.1.0
+django-geojson==4.0.0
 django-revproxy==0.10.0
 djangorestframework==3.14.0
 idna==3.4

--- a/sitn/settings.py
+++ b/sitn/settings.py
@@ -54,6 +54,7 @@ INTERNET_ONLY_APPS = [
 ]
 
 INSTALLED_APPS = [
+    "corsheaders",
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -69,6 +70,7 @@ else:
     INSTALLED_APPS = INTERNET_ONLY_APPS + INSTALLED_APPS
 
 MIDDLEWARE = [
+    "corsheaders.middleware.CorsMiddleware",
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -171,6 +173,8 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'assets')
 STATICFILES_DIRS = [
     BASE_DIR / "static",
 ]
+
+CORS_ALLOWED_ORIGINS = os.environ["CORS_ALLOWED_ORIGINS"].split(",")
 
 CSRF_COOKIE_SECURE = True
 CSRF_COOKIE_DOMAIN = os.environ["CSRF_COOKIE_DOMAIN"]


### PR DESCRIPTION
This PR:
- Adds CORS allowing preflight OPTIONS to be made before POST
- Groups polygons by 'type_localisation' and exposes areas in an attribute

djgeojson is needed because Django serializer doesn't like `annotation` attributes that are not in the model.