### PR TITLE
edit guid valid forever

### DIFF
--- a/health/admin.py
+++ b/health/admin.py
@@ -5,6 +5,7 @@ from health.models import St20AvailableDoctors, St21AvailableDoctorsWithGeom, St
 class St20AvailableDoctorsAdmin(admin.ModelAdmin):
     model = St20AvailableDoctors
     search_fields = ['doctor__id_person_address', 'doctor__nom', 'doctor__prenoms']
+    readonly_fields = ['login_email']
     list_display = [
         'pk',
         'nom',

--- a/health/models.py
+++ b/health/models.py
@@ -132,13 +132,6 @@ class St20AvailableDoctors(AbstractDoctors):
         if not bool(self.edit_guid):
             logger.info('Edit guid is empty or null')
             return False
-        now = timezone.now()
-        three_days_ago = now - timedelta(days=3)
-        if self.guid_requested_when == None:
-            return False
-        if self.guid_requested_when < three_days_ago:
-            logger.info('Edit guid is older than three days ago')
-            return False
         return True
 
     def clean(self):

--- a/health/serializers.py
+++ b/health/serializers.py
@@ -5,15 +5,11 @@ from health.models import St20AvailableDoctors, St21AvailableDoctorsWithGeom, St
 
 class St20AvailableDoctorsSerializer(serializers.HyperlinkedModelSerializer):
     id_person_address = serializers.SerializerMethodField()
-    email1 = serializers.EmailField(write_only=True, required=False)
-    email2 = serializers.EmailField(write_only=True, required=False)
     class Meta:
         model = St20AvailableDoctors
         fields = [
             'url',
             'id_person_address',
-            'email1',
-            'email2',
             'availability_conditions',
             'public_phone',
             'public_first_name',
@@ -31,18 +27,8 @@ class St20AvailableDoctorsSerializer(serializers.HyperlinkedModelSerializer):
 
     def get_id_person_address(self, obj):
         return obj.pk
-    
-    def validate(self, data):
-        validated_data = super().validate(data)
-        if 'email1' in validated_data.keys():
-            if validated_data['email1'] != data['email2']:
-                raise serializers.ValidationError("The two email fields didn't match.")
-        return validated_data
 
     def update(self, instance, validated_data):
-        if 'email1' in validated_data.keys():
-            validated_data.pop('email2')
-            instance.login_email = validated_data.pop('email1')
         instance.edit_guid = None
         instance.guid_requested_when = None
         instance.last_edit = timezone.now()

--- a/health/tests.py
+++ b/health/tests.py
@@ -95,11 +95,8 @@ class HealthApiTest(APITestCase):
         url = f'/health/doctors/edit/{doctor.edit_guid}/'
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        new_email = "test@example.com"
 
         new_data = {
-            "email1": new_email,
-            "email2": new_email,
             "spoken_languages": [
                 "Français"
             ],
@@ -112,7 +109,6 @@ class HealthApiTest(APITestCase):
         response = self.client.put(url, new_data)
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         doctor = St20AvailableDoctors.objects.get(pk=doctor.pk)
-        self.assertEqual(doctor.login_email, new_email, "Email has been updated")
         self.assertEqual(doctor.public_phone, "", "Phone is empty")
         self.assertIsNone(doctor.edit_guid, 'edit_guid should have been deleted by the update')
         self.assertIsNone(doctor.guid_requested_when)


### PR DESCRIPTION
It's better to allow the edit guid to be used after 3 days because some doctors don't answer emails directly :) This PR makes edit guid valid for eternity
Also, this PR disables the possibility to edit login_email for doctors