### PR TITLE
hide nemedreg in admin, doctor readonly

### DIFF
--- a/health/admin.py
+++ b/health/admin.py
@@ -5,7 +5,7 @@ from health.models import St20AvailableDoctors, St21AvailableDoctorsWithGeom, St
 class St20AvailableDoctorsAdmin(admin.ModelAdmin):
     model = St20AvailableDoctors
     search_fields = ['doctor__id_person_address', 'doctor__nom', 'doctor__prenoms']
-    readonly_fields = ['login_email']
+    readonly_fields = ['login_email', 'doctor']
     list_display = [
         'pk',
         'nom',
@@ -64,4 +64,3 @@ class St22DoctorChangeSuggestionAdmin(admin.ModelAdmin):
 
 admin.site.register(St22DoctorChangeSuggestion, St22DoctorChangeSuggestionAdmin)
 admin.site.register(St20AvailableDoctors, St20AvailableDoctorsAdmin)
-admin.site.register(St21AvailableDoctorsWithGeom, St21AvailableDoctorsWithGeomAdmin)


### PR DESCRIPTION
This PR is just a cosmetic in admin:
- Hides Nemedreg because it has nothing to do in admin
- Turns the link to nemedreg to readonly as it is managed automatically