### PR TITLE
expose cadastre

### DIFF
--- a/cadastre/models.py
+++ b/cadastre/models.py
@@ -57,6 +57,7 @@ class Mo9Immeubles(models.Model):
     idobj = models.CharField(max_length=40, primary_key=True)
     nummai = models.CharField(max_length=7)
     numcad = models.IntegerField(db_column="numcom")
+    cadastre = models.CharField(max_length=50)
     idmai = models.CharField(max_length=50, db_column="id")
     egrid = models.CharField(max_length=14)
     geom = models.MultiPolygonField(srid=settings.DEFAULT_SRID)

--- a/ecap/tests.py
+++ b/ecap/tests.py
@@ -1,10 +1,5 @@
-from django.utils import timezone
-
 from rest_framework import status
 from rest_framework.test import APITestCase
-
-from cadastre.models import Mo9Immeubles
-
 
 class EcapApiTest(APITestCase):
     def setUp(self) -> None:
@@ -29,6 +24,8 @@ class EcapApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
         self.assertGreater(len(data['features']), 1)
+        first_estate = data['features'][0]
+        self.assertIn('cadastre', first_estate['properties'], 'Cadastre is given in answer')
 
     def test_estate_limit(self):
         """

--- a/sitn/settings.py
+++ b/sitn/settings.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 from dotenv import load_dotenv
 
-load_dotenv('.env')
+load_dotenv('.env', override=True)
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
This PR exposes cadastre name on estates:

Deployed on prepub for testing: https://sitn.ne.ch/apps_prepub/ecap/estate?east=2562165&north=1205258

![image](https://github.com/user-attachments/assets/c668126e-e8ae-475d-bc73-cec6315f3936)
