### PR TITLE
allow multiline origins

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -35,7 +35,10 @@ GEOS_LIBRARY_PATH="C:/PostgreSQL/XXX/bin/libgeos_c.dll"
 DOCKER_HOST=ssh://user@server.example.com
 
 ALLOWED_HOSTS="example.com,example2.com"
-CORS_ALLOWED_ORIGINS="http://localhost:5173,https://sitn.ne.ch"
+
+# List of allowed origins, can be multiline
+CORS_ALLOWED_ORIGINS="http://localhost:5173,
+https://sitn.ne.ch"
 EMAIL_HOST=smtp.example.com
 
 # You can set your production base URL here like:

--- a/sitn/settings.py
+++ b/sitn/settings.py
@@ -170,7 +170,8 @@ CORS_DEV_ORIGINS = [
     "https://localhost:4300",
     "http://localhost:5173"
 ]
-CORS_ALLOWED_ORIGINS = CORS_DEV_ORIGINS + os.environ["CORS_ALLOWED_ORIGINS"].split(",")
+
+CORS_ALLOWED_ORIGINS = CORS_DEV_ORIGINS + list(map(str.rstrip, os.environ["CORS_ALLOWED_ORIGINS"].split(",")))
 
 CSRF_USE_SESSIONS = True
 CSRF_COOKIE_SECURE = True


### PR DESCRIPTION
Because in production we will have two more origins, it's handy to have them listed in the .env with new lines