### PR TITLE
expose list of possible sinistres

### DIFF
--- a/ecap_intra/models.py
+++ b/ecap_intra/models.py
@@ -72,3 +72,12 @@ class PlanSpecial(models.Model, GeoJSONModelMixin):
     class Meta:
         db_table = 'amenagement\".\"at205_plans_speciaux'
         managed = False
+
+
+class Ecap90RepartitionExpertsSinistre(models.Model):
+    idobj = models.TextField(primary_key=True)
+    name_sinistre = models.TextField()
+
+    class Meta:
+        db_table = 'ecap\".\"ecap90_repartition_experts_sinistre'
+        managed = False

--- a/ecap_intra/tests.py
+++ b/ecap_intra/tests.py
@@ -36,3 +36,13 @@ class EcapApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
         self.assertEqual(len(data['features']), 200)
+
+    def test_sinistres(self):
+        """
+        Tests json of sinistres is a list
+        """
+        url = '/ecap/sinistres-exceptionnels/'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertGreater(len(data), 2)

--- a/ecap_intra/urls.py
+++ b/ecap_intra/urls.py
@@ -11,9 +11,11 @@ router.register(r'plansquartiers', views.PlanQuartierViewSet)
 router.register(r'planspeciaux', views.PlanSpecialViewSet)
 router.register_additional_route_to_root('estate', 'ecap-intra-estate')
 router.register_additional_route_to_root('search', 'ecap-intra-search')
+router.register_additional_route_to_root('sinistres-exceptionnels', 'ecap-intra-sinistres-exceptionnels')
 
 urlpatterns = [
     path('', include(router.urls)),
     path('estate/', views.get_estate, name='ecap-intra-estate'),
     path('search/', search_parcel, name='ecap-intra-search'),
+    path('sinistres-exceptionnels/', views.get_sinistres, name='ecap-intra-sinistres-exceptionnels'),
 ]

--- a/ecap_intra/views.py
+++ b/ecap_intra/views.py
@@ -7,6 +7,7 @@ from django.http import JsonResponse
 from rest_framework import viewsets
 from rest_framework.decorators import action, api_view
 from rest_framework_gis.pagination import GeoJsonPagination
+from rest_framework.response import Response
 
 from cadastre.models import Mo9Immeubles
 from sitn.mixins import MultiSerializerMixin
@@ -15,6 +16,7 @@ from ecap_intra.models import (
     RepartitionExpert,
     PlanSpecial,
     PlanQuartier,
+    Ecap90RepartitionExpertsSinistre
 )
 from ecap_intra.serializers import (
     ObjetImmobiliseSerializer,
@@ -132,3 +134,13 @@ class PlanSpecialViewSet(viewsets.ReadOnlyModelViewSet):
     def download(self, request):
         data = PlanSpecial.as_geojson()
         return JsonResponse(data, safe=False, json_dumps_params={"ensure_ascii": False})
+
+
+@api_view(["GET"])
+def get_sinistres(request):
+    """
+    Retrieves a list of available "secteurs d'intervention" related to a "sinistre"
+    """
+    sinistres = Ecap90RepartitionExpertsSinistre.objects.values_list('name_sinistre', flat=True).distinct()
+
+    return Response(sinistres)


### PR DESCRIPTION
If anyone of you could review this PR:
- Adds a new endpoint to list all the _sinistres_ that have a special perimeter _de répartition des experts_. Why? Because they're using WFS and WMS from our geoportal and they need to filter a layer with distinct values. 