### PR TITLE
add preavis endpoint

### DIFF
--- a/ecap_intra/models.py
+++ b/ecap_intra/models.py
@@ -81,3 +81,12 @@ class Ecap90RepartitionExpertsSinistre(models.Model):
     class Meta:
         db_table = 'ecap\".\"ecap90_repartition_experts_sinistre'
         managed = False
+
+
+class Ecap06Preavis(models.Model):
+    idobj = models.IntegerField(primary_key=True)
+    document_name = models.TextField()
+
+    class Meta:
+        db_table = 'ecap\".\"ecap06_preavis'
+        managed = False

--- a/ecap_intra/tests.py
+++ b/ecap_intra/tests.py
@@ -46,3 +46,13 @@ class EcapApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
         self.assertGreater(len(data), 2)
+
+    def test_preavis(self):
+        """
+        Tests json of preavis is a list
+        """
+        url = '/ecap/preavis/'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertGreater(len(data), 2)

--- a/ecap_intra/urls.py
+++ b/ecap_intra/urls.py
@@ -12,10 +12,12 @@ router.register(r'planspeciaux', views.PlanSpecialViewSet)
 router.register_additional_route_to_root('estate', 'ecap-intra-estate')
 router.register_additional_route_to_root('search', 'ecap-intra-search')
 router.register_additional_route_to_root('sinistres-exceptionnels', 'ecap-intra-sinistres-exceptionnels')
+router.register_additional_route_to_root('preavis', 'ecap-preavis')
 
 urlpatterns = [
     path('', include(router.urls)),
     path('estate/', views.get_estate, name='ecap-intra-estate'),
     path('search/', search_parcel, name='ecap-intra-search'),
     path('sinistres-exceptionnels/', views.get_sinistres, name='ecap-intra-sinistres-exceptionnels'),
+    path('preavis/', views.get_preavis, name='ecap-preavis'),
 ]

--- a/ecap_intra/views.py
+++ b/ecap_intra/views.py
@@ -16,7 +16,8 @@ from ecap_intra.models import (
     RepartitionExpert,
     PlanSpecial,
     PlanQuartier,
-    Ecap90RepartitionExpertsSinistre
+    Ecap90RepartitionExpertsSinistre,
+    Ecap06Preavis,
 )
 from ecap_intra.serializers import (
     ObjetImmobiliseSerializer,
@@ -144,3 +145,14 @@ def get_sinistres(request):
     sinistres = Ecap90RepartitionExpertsSinistre.objects.values_list('name_sinistre', flat=True).distinct()
 
     return Response(sinistres)
+
+
+@api_view(["GET"])
+def get_preavis(request):
+    """
+    Retrieves a list of available "preavis". "Preavis" are preliminary geometries draw on intranet
+    geoportal. They refer to future "plans de quartier" or "plans spéciaux"
+    """
+    preavis = Ecap06Preavis.objects.values_list('document_name', flat=True).distinct()
+
+    return Response(preavis)


### PR DESCRIPTION
A new endpoint for ECAP, the list of "préavis" they draw in the géoportal so they can link them on their ERP
https://sitnintra.ne.ch/apps/ecap/preavis/
