### PR TITLE
check env

### DIFF
--- a/deploy
+++ b/deploy
@@ -7,10 +7,37 @@ import re
 import sys
 from pathlib import Path
 from dotenv import load_dotenv
+import hashlib
 
-CONTEXTS = ["internet", "intranet", "dev"]
+# hashes of the content of .env files
+CONTEXTS = {
+    "internet": "D9ED3EF801A8DC7826C42FA972046EF2",
+    "intranet": "BF91BBF458123A9E9465B19E6FE254B3"
+}
 ALLOWED_INSTANCES = ["prepub", "prod", "dev", "local"]
 
+
+def get_md5_file_content(file):
+    with open(file, "rb") as f:
+        return hashlib.md5(f.read()).hexdigest()
+
+def is_env_up_to_date(env_file, context, instance):
+    expected_hash = CONTEXTS[context].lower()
+    current_hash = get_md5_file_content(env_file)
+    if instance != "prod":
+        return True
+    if expected_hash == current_hash:
+        return True
+    print(f"💥 Votre fichier {env_file} ne correspond pas à celui du keepass!")
+    print(f"""
+Mettez à jour votre fichier. Si votre modification locale est légitime,
+obtenez un nouveau hash avec 'Get-FileHash -Algorithm MD5 {env_file}'
+et copiez ce nouveau hash dans CONTEXTS du fichier deploy (ce scipt).
+
+N'oubliez pas de tenir le keepass à jour 😉
+    """)
+    sys.exit(f"ERREUR: {env_file} pas à jour!")
+    return False
 
 def check_settings_file(dest_instance):
     # Do not deploy to the internet with DEBUG set to True
@@ -45,6 +72,7 @@ def main():
     env_file = f".env.{context}.{instance}"
     os.environ['ENV_FILE'] = env_file
     load_dotenv(Path(env_file), override=True)
+    is_env_up_to_date(env_file, context, instance)
 
     dest_docker_host = os.environ['DOCKER_HOST']
     os.environ['DOCKER_HOST'] = ""


### PR DESCRIPTION
Sometimes we update .env files and sitn_applications is not modified often so developpers forget to update their .env files.

To avoid a deploy to production without an up to date .env file, I've added a check based on the checksum of the content.